### PR TITLE
Add some options to ReaderViewController

### DIFF
--- a/Sources/ReaderViewController.h
+++ b/Sources/ReaderViewController.h
@@ -74,6 +74,7 @@
 
 @property BOOL shouldDisplayToolbarsAutomatically;
 @property BOOL shouldDisplayToolbarsOnTap;
+@property (nonatomic, strong, readwrite) UIColor *backgroundColor;
 
 - (id)initWithReaderDocument:(ReaderDocument *)object;
 

--- a/Sources/ReaderViewController.m
+++ b/Sources/ReaderViewController.m
@@ -44,6 +44,7 @@
 @synthesize delegate;
 @synthesize shouldDisplayToolbarsAutomatically = _shouldDisplayToolbarsAutomatically;
 @synthesize shouldDisplayToolbarsOnTap = _shouldDisplayToolbarsOnTap;
+@synthesize backgroundColor = _backgroundColor;
 
 #pragma mark Support methods
 
@@ -326,7 +327,11 @@
 
 	assert(self.splitViewController == nil); // Not supported (sorry)
 
-	self.view.backgroundColor = [UIColor scrollViewTexturedBackgroundColor];
+	if ([self backgroundColor] == nil) {
+		self.view.backgroundColor = [UIColor scrollViewTexturedBackgroundColor];
+	} else {
+		self.view.backgroundColor = [self backgroundColor];
+	}
 
 	CGRect viewRect = self.view.bounds; // View controller's view bounds
 


### PR DESCRIPTION
We’ve added some properties on ReaderViewController to allow it to be embedded with a custom background color and no toolbars if you desire.
