### PR TITLE
Implement fast-pagination

### DIFF
--- a/Sources/ReaderViewController.m
+++ b/Sources/ReaderViewController.m
@@ -53,6 +53,8 @@
 	UIPrintInteractionController *printInteraction;
 
 	NSInteger currentPage;
+    
+    NSInteger currentScrollViewPage;
 
 	CGSize lastAppearSize;
 
@@ -436,7 +438,7 @@
 
 	theScrollView = nil; contentViews = nil; lastHideTime = nil;
 
-	lastAppearSize = CGSizeZero; currentPage = 0;
+	lastAppearSize = CGSizeZero; currentPage = 0; currentScrollViewPage = 0;
 
 	[super viewDidUnload];
 }
@@ -500,25 +502,37 @@
 
 #pragma mark UIScrollViewDelegate methods
 
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-	__block NSInteger page = 0;
-
-	CGFloat contentOffsetX = scrollView.contentOffset.x;
-
-	[contentViews enumerateKeysAndObjectsUsingBlock: // Enumerate content views
-		^(id key, id object, BOOL *stop)
-		{
-			ReaderContentView *contentView = object;
-
-			if (contentView.frame.origin.x == contentOffsetX)
-			{
-				page = contentView.tag; *stop = YES;
-			}
-		}
-	];
-
-	if (page != 0) [self showDocumentPage:page]; // Show the page
+    NSInteger scrollViewPage = 0;
+    CGFloat pageWidth = scrollView.frame.size.width;
+    CGFloat contentOffsetX = scrollView.contentOffset.x;
+    
+    if ((currentScrollViewPage == 0 && contentOffsetX < pageWidth) || contentOffsetX <= 0) {
+        scrollViewPage = 0;
+    } else if ((currentScrollViewPage == 2 && contentOffsetX <= pageWidth) || (currentScrollViewPage != 2 && contentOffsetX < 2 * pageWidth)) {
+        scrollViewPage = 1;
+    } else {
+        scrollViewPage = 2;
+    }
+    
+    if (scrollViewPage != currentScrollViewPage) {
+        currentScrollViewPage = scrollViewPage;
+        
+        CGFloat contentOffsetX = scrollView.frame.size.width * scrollViewPage;
+        
+        __block NSInteger page = 0;
+        
+        [contentViews enumerateKeysAndObjectsUsingBlock:^(id key, ReaderContentView *contentView, BOOL *stop) {
+            if (contentView.frame.origin.x == contentOffsetX) {
+                page = contentView.tag; *stop = YES;
+            }
+        }];
+        
+        if (page != 0)  {
+            [self showDocumentPage:page]; // Show the page
+        }
+    }
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView


### PR DESCRIPTION
Hi - nice project. I have been using this library within a project I am working on and it has been great. One thing that I felt needed improvement was the pagination. When you reached the end of the preloaded pages (3 by default), you will get a "bounce" and have to wait until the scroll view decelerates until you can continue. 

This made it rather difficult to scroll quickly through several pages quickly. I have adjusted the behaviour in this feature branch to fix that annoyance.

I have made several other customisations to the project, I will likely publish them as separate branches and do pull requests when I think they are ready (and if you'd like them), however I feel this patch is beneficial to almost everyone as it improves user experience.

Cheers!
