### PR TITLE
Added option to enable single finger double tap zoom in/out.

### DIFF
--- a/Sources/ReaderConstants.h
+++ b/Sources/ReaderConstants.h
@@ -38,5 +38,6 @@
 #define READER_DISABLE_IDLE FALSE
 #define READER_SHOW_SHADOWS TRUE
 #define READER_STANDALONE FALSE
+#define READER_SINGLETAPZOOM TRUE
 
 extern NSString *const kReaderCopyrightNotice;

--- a/Sources/ReaderContentView.h
+++ b/Sources/ReaderContentView.h
@@ -52,6 +52,7 @@
 - (void)zoomIncrement;
 - (void)zoomDecrement;
 - (void)zoomReset;
+- (void)zoomToggle;
 
 @end
 

--- a/Sources/ReaderContentView.m
+++ b/Sources/ReaderContentView.m
@@ -272,6 +272,18 @@ static inline CGFloat ZoomScaleThatFits(CGSize target, CGSize source)
 	}
 }
 
+- (void)zoomToggle
+{
+	if (self.zoomScale > self.minimumZoomScale)
+	{
+        [self setZoomScale:self.minimumZoomScale animated:YES];
+	}
+    else
+    {
+        [self setZoomScale:self.maximumZoomScale animated:YES];
+    }
+}
+
 #pragma mark UIScrollViewDelegate methods
 
 - (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView

--- a/Sources/ReaderDocumentOutline.m
+++ b/Sources/ReaderDocumentOutline.m
@@ -26,6 +26,12 @@
 #import "ReaderDocumentOutline.h"
 #import "CGPDFDocument.h"
 
+@interface ReaderDocumentOutline()
+
+void logDictionaryEntry(const char *key, CGPDFObjectRef object, void *info);
+
+@end
+
 @implementation ReaderDocumentOutline
 
 #pragma mark Build option flags

--- a/Sources/ReaderViewController.m
+++ b/Sources/ReaderViewController.m
@@ -368,9 +368,11 @@
 	doubleTapOne.numberOfTouchesRequired = 1; doubleTapOne.numberOfTapsRequired = 2; doubleTapOne.delegate = self;
 	[self.view addGestureRecognizer:doubleTapOne];
 
+#if (READER_SINGLETAPZOOM == FALSE) // Option
 	UITapGestureRecognizer *doubleTapTwo = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
 	doubleTapTwo.numberOfTouchesRequired = 2; doubleTapTwo.numberOfTapsRequired = 2; doubleTapTwo.delegate = self;
 	[self.view addGestureRecognizer:doubleTapTwo];
+#endif
 
 	[singleTapOne requireGestureRecognizerToFail:doubleTapOne]; // Single tap requires double tap to fail
 
@@ -687,6 +689,9 @@
 
 			ReaderContentView *targetView = [contentViews objectForKey:key];
 
+#if (READER_SINGLETAPZOOM == TRUE) // Option
+			[targetView zoomToggle];
+#else
 			switch (recognizer.numberOfTouchesRequired) // Touches count
 			{
 				case 1: // One finger double tap: zoom ++
@@ -699,7 +704,7 @@
 					[targetView zoomDecrement]; break;
 				}
 			}
-
+#endif
 			return;
 		}
 


### PR DESCRIPTION
The VFR Reader was just what I needed for the project I am working on.  However, given my client, I felt that it was important to keep the expected single finger double tap behaviour of their current interface.

The option can be enabled/disabled in the constants.h file by modifying 'READER_SINGLETAPZOOM'.
