### PR TITLE
Expose pageWidth and pageHeight of ReaderContentPage to derived classes.

### DIFF
--- a/Sources/ReaderContentPage.h
+++ b/Sources/ReaderContentPage.h
@@ -31,6 +31,9 @@
 
 - (id)processSingleTap:(UITapGestureRecognizer *)recognizer;
 
+@property (nonatomic, readonly) CGFloat pageWidth;
+@property (nonatomic, readonly) CGFloat pageHeight;
+
 @end
 
 #pragma mark -

--- a/Sources/ReaderContentPage.h
+++ b/Sources/ReaderContentPage.h
@@ -25,7 +25,18 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ReaderContentPage : UIView
+@interface ReaderContentPage : UIView {
+    NSMutableArray *_links;
+    
+    CGPDFDocumentRef _PDFDocRef;
+    
+    CGPDFPageRef _PDFPageRef;
+    
+    NSInteger _pageAngle;
+    
+    CGFloat _pageOffsetX;
+    CGFloat _pageOffsetY;
+}
 
 - (instancetype)initWithURL:(NSURL *)fileURL page:(NSInteger)page password:(NSString *)phrase;
 

--- a/Sources/ReaderContentPage.m
+++ b/Sources/ReaderContentPage.m
@@ -36,19 +36,6 @@
 @end
 
 @implementation ReaderContentPage
-{
-	NSMutableArray *_links;
-
-	CGPDFDocumentRef _PDFDocRef;
-
-	CGPDFPageRef _PDFPageRef;
-
-	NSInteger _pageAngle;
-
-	CGFloat _pageOffsetX;
-	CGFloat _pageOffsetY;
-}
-
 
 #pragma mark - ReaderContentPage class methods
 

--- a/Sources/ReaderContentPage.m
+++ b/Sources/ReaderContentPage.m
@@ -28,6 +28,13 @@
 #import "ReaderContentTile.h"
 #import "CGPDFDocument.h"
 
+@interface ReaderContentPage ()
+
+@property (nonatomic) CGFloat pageWidth;
+@property (nonatomic) CGFloat pageHeight;
+
+@end
+
 @implementation ReaderContentPage
 {
 	NSMutableArray *_links;
@@ -38,12 +45,10 @@
 
 	NSInteger _pageAngle;
 
-	CGFloat _pageWidth;
-	CGFloat _pageHeight;
-
 	CGFloat _pageOffsetX;
 	CGFloat _pageOffsetY;
 }
+
 
 #pragma mark - ReaderContentPage class methods
 


### PR DESCRIPTION
**CONTEXT**

We're using a highly customised version of vfrReader for one of our projects. In order to do various transforms we need to know the size of a ReaderContentPage, but it is not cleanly exposed in the current implementation

**WHAT THIS PR DOES**

This PR simply exposes the 2 variables pageWidth and pageHeight as properties, so that outside (and derived) classes can read them.

**WHY IS IT NECESSARY?**
Without this change, derived classes have to re-read the page info from the pdf context.

**ALTERNATIVE SOLUTION**
If you're not keen on exposing this as a property, perhaps it could be made protected using @protected instead?
