### PR TITLE
Customisable Reader

### DIFF
--- a/Classes/ReaderDemoController.m
+++ b/Classes/ReaderDemoController.m
@@ -177,10 +177,22 @@
 	NSString *filePath = [pdfs firstObject]; assert(filePath != nil); // Path to first PDF file
 
 	ReaderDocument *document = [ReaderDocument withDocumentFilePath:filePath password:phrase];
+	document.displayName = @"Nice Title";
+	
+	// Customize Toolbar
+	document.canEmail = NO;
+	document.canExport = NO;
+	document.canPrint = NO;
 
 	if (document != nil) // Must have a valid ReaderDocument object in order to proceed with things
 	{
 		ReaderViewController *readerViewController = [[ReaderViewController alloc] initWithReaderDocument:document];
+		
+		// Customize Document Background and Shadow
+		readerViewController.documentBackgroundColor = [UIColor grayColor];
+		readerViewController.thumbnailsBackgroundColor = [UIColor grayColor];
+		readerViewController.displayShadow = NO;
+		readerViewController.thumbnailsOnly = YES; // Will only show the thumbnail view of the document.
 
 		readerViewController.delegate = self; // Set the ReaderViewController delegate to self
 

--- a/Sources/ReaderContentView.h
+++ b/Sources/ReaderContentView.h
@@ -42,6 +42,7 @@
 @interface ReaderContentView : UIScrollView
 
 @property (nonatomic, weak, readwrite) id <ReaderContentViewDelegate> message;
+@property (nonatomic) BOOL displayShadow;
 
 - (instancetype)initWithFrame:(CGRect)frame fileURL:(NSURL *)fileURL page:(NSUInteger)page password:(NSString *)phrase;
 

--- a/Sources/ReaderContentView.m
+++ b/Sources/ReaderContentView.m
@@ -65,6 +65,7 @@ static CGFloat g_BugFixWidthInset = 0.0f;
 #pragma mark - Properties
 
 @synthesize message;
+@synthesize displayShadow = _displayShadow;
 
 #pragma mark - ReaderContentView functions
 
@@ -154,11 +155,11 @@ static inline CGFloat zoomScaleThatFits(CGSize target, CGSize source)
 			theContainerView.backgroundColor = [UIColor whiteColor];
 
 #if (READER_SHOW_SHADOWS == TRUE) // Option
-
-			theContainerView.layer.shadowOffset = CGSizeMake(0.0f, 0.0f);
-			theContainerView.layer.shadowRadius = 4.0f; theContainerView.layer.shadowOpacity = 1.0f;
-			theContainerView.layer.shadowPath = [UIBezierPath bezierPathWithRect:theContainerView.bounds].CGPath;
-
+			if (_displayShadow) {
+				theContainerView.layer.shadowOffset = CGSizeMake(0.0f, 0.0f);
+				theContainerView.layer.shadowRadius = 4.0f; theContainerView.layer.shadowOpacity = 1.0f;
+				theContainerView.layer.shadowPath = [UIBezierPath bezierPathWithRect:theContainerView.bounds].CGPath;
+			}
 #endif // end of READER_SHOW_SHADOWS Option
 
 			self.contentSize = theContentPage.bounds.size; [self centerScrollViewContent];

--- a/Sources/ReaderDocument.h
+++ b/Sources/ReaderDocument.h
@@ -37,10 +37,11 @@
 @property (nonatomic, strong, readonly) NSString *password;
 @property (nonatomic, strong, readonly) NSString *fileName;
 @property (nonatomic, strong, readonly) NSURL *fileURL;
+@property (nonatomic, strong) NSString *displayName;
 
-@property (nonatomic, readonly) BOOL canEmail;
-@property (nonatomic, readonly) BOOL canExport;
-@property (nonatomic, readonly) BOOL canPrint;
+@property (nonatomic) BOOL canEmail;
+@property (nonatomic) BOOL canExport;
+@property (nonatomic) BOOL canPrint;
 
 + (ReaderDocument *)withDocumentFilePath:(NSString *)filePath password:(NSString *)phrase;
 

--- a/Sources/ReaderDocument.m
+++ b/Sources/ReaderDocument.m
@@ -71,7 +71,8 @@
 @synthesize password = _password;
 @synthesize filePath = _filePath;
 @dynamic fileName, fileURL;
-@dynamic canEmail, canExport, canPrint;
+@synthesize displayName = _displayName;
+@synthesize canEmail = _canEmail, canExport = _canExport, canPrint = _canPrint;
 
 #pragma mark - ReaderDocument class methods
 
@@ -158,6 +159,8 @@
 	{
 		document = [[ReaderDocument alloc] initWithFilePath:filePath password:phrase];
 	}
+    
+	document.displayName = [[document.fileName copy] stringByDeletingPathExtension]; // Default Display-Name
 
 	return document;
 }
@@ -255,21 +258,6 @@
 	if (_fileURL == nil) _fileURL = [[NSURL alloc] initFileURLWithPath:_filePath isDirectory:NO];
 
 	return _fileURL;
-}
-
-- (BOOL)canEmail
-{
-	return YES;
-}
-
-- (BOOL)canExport
-{
-	return YES;
-}
-
-- (BOOL)canPrint
-{
-	return YES;
 }
 
 - (BOOL)archiveDocumentProperties

--- a/Sources/ReaderMainToolbar.m
+++ b/Sources/ReaderMainToolbar.m
@@ -233,7 +233,7 @@
 			titleLabel.backgroundColor = [UIColor clearColor];
 			titleLabel.adjustsFontSizeToFitWidth = YES;
 			titleLabel.minimumScaleFactor = 0.75f;
-			titleLabel.text = [document.fileName stringByDeletingPathExtension];
+			titleLabel.text = document.displayName;
 #if (READER_FLAT_UI == FALSE) // Option
 			titleLabel.shadowColor = [UIColor colorWithWhite:0.75f alpha:1.0f];
 			titleLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);

--- a/Sources/ReaderViewController.h
+++ b/Sources/ReaderViewController.h
@@ -40,6 +40,10 @@
 @interface ReaderViewController : UIViewController
 
 @property (nonatomic, weak, readwrite) id <ReaderViewControllerDelegate> delegate;
+@property (nonatomic) BOOL thumbnailsOnly;
+@property (nonatomic) BOOL displayShadow;
+@property (nonatomic) UIColor *documentBackgroundColor;
+@property (nonatomic) UIColor *thumbnailsBackgroundColor;
 
 - (instancetype)initWithReaderDocument:(ReaderDocument *)object;
 

--- a/Sources/ThumbsViewController.h
+++ b/Sources/ThumbsViewController.h
@@ -44,6 +44,9 @@
 @interface ThumbsViewController : UIViewController
 
 @property (nonatomic, weak, readwrite) id <ThumbsViewControllerDelegate> delegate;
+@property (nonatomic) BOOL thumbnailsOnly;
+@property (nonatomic) BOOL displayShadow;
+@property (nonatomic) UIColor *thumbnailsBackgroundColor;
 
 - (instancetype)initWithReaderDocument:(ReaderDocument *)object;
 
@@ -56,6 +59,8 @@
 //
 
 @interface ThumbsPageThumb : ReaderThumbView
+
+@property (nonatomic) BOOL displayShadow;
 
 - (CGSize)maximumContentSize;
 

--- a/Sources/ThumbsViewController.m
+++ b/Sources/ThumbsViewController.m
@@ -118,7 +118,7 @@
 		}
 	}
 
-	NSString *toolbarTitle = [document.fileName stringByDeletingPathExtension];
+	NSString *toolbarTitle = document.displayName; // use same title as document
 
 	CGRect toolbarRect = scrollViewRect; // Toolbar frame
 	toolbarRect.size.height = TOOLBAR_HEIGHT; // Default toolbar height


### PR DESCRIPTION
When using reader core as a pod, some settings cannot be changed. Now you can customize the toolbar, background colors and shadows. There is also a thumbnails-only view-mode.

Signed-off-by: Tom Kremer kremer.tom@gmail.com
