### PR TITLE
stringByAddingPercentEscapesUsingEncoding Deprecated in 9

### DIFF
--- a/Sources/ReaderContentPage.m
+++ b/Sources/ReaderContentPage.m
@@ -284,8 +284,13 @@
 						const char *uri = (const char *)CGPDFStringGetBytePtr(uriString); // Destination URI string
 
 						NSString *target = [NSString stringWithCString:uri encoding:NSUTF8StringEncoding]; // NSString - UTF8
-
-						linkTarget = [NSURL URLWithString:[target stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+                        
+                        NSMutableCharacterSet *alphaNumSymbols = [NSMutableCharacterSet characterSetWithCharactersInString:@"~!@#$&*()-_+=[]:;',/?."];
+                        [alphaNumSymbols formUnionWithCharacterSet:[NSCharacterSet alphanumericCharacterSet]];
+                        
+                        target = [target stringByAddingPercentEncodingWithAllowedCharacters:alphaNumSymbols];
+                        
+                        linkTarget = [NSURL URLWithString:target];
 
 						if (linkTarget == nil) NSLog(@"%s Bad URI '%@'", __FUNCTION__, target);
 					}


### PR DESCRIPTION

stringByAddingPercentEscapesUsingEncoding is deprecated as of iOS9.0 replaced with stringByAddingPercentEncodingWithAllowedCharacters.

[https://developer.apple.com/documentation/foundation/nsstring/1415058-stringbyaddingpercentescapesusin](https://developer.apple.com/documentation/foundation/nsstring/1415058-stringbyaddingpercentescapesusin)

This also addresses a bug where external anchor links with a # in the name are incorrectly encoded to %23. i.e. http://site/index.html#anchor is sent to http://site/index.html%23anchor

Reference SO
[https://meta.stackexchange.com/questions/259368/ios-app-url-percent-encoding-and-decoding-bug](https://meta.stackexchange.com/questions/259368/ios-app-url-percent-encoding-and-decoding-bug)
